### PR TITLE
Fix vertical squashing of the panel icons

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -173,7 +173,7 @@ var TeaTime = class extends PanelMenu.Button {
 
 			this._settings = Utils.getSettings();
 
-			this._logo = new Icon.TwoColorIcon(24, Icon.TeaPot);
+			this._logo = new Icon.TwoColorIcon(20, Icon.TeaPot);
 
 			// set timer widget
 			this._textualTimer = new St.Label({
@@ -181,7 +181,7 @@ var TeaTime = class extends PanelMenu.Button {
 				x_align: Clutter.ActorAlign.END,
 				y_align: Clutter.ActorAlign.CENTER
 			});
-			this._graphicalTimer = new Icon.TwoColorIcon(24, Icon.Pie);
+			this._graphicalTimer = new Icon.TwoColorIcon(20, Icon.Pie);
 
 			this.actor.add_actor(this._logo);
 			this.actor.add_style_class_name('panel-status-button');

--- a/src/icon.js
+++ b/src/icon.js
@@ -20,7 +20,7 @@ var TwoColorIcon = class extends St.DrawingArea {
 	constructor(size, drawingObject) {
 		super({
 			reactive: true,
-			style: 'padding: 0px 2px'
+			style: 'padding: 0px 0px'
 		});
 		this.myinit = function () {
 			this._base_size = size;


### PR DESCRIPTION
The teapot and especially the progress circle icon in the panel are
squashed with GNOME-3.32. The problem appears to be that the padding
which we are requesting gets applied not only to the surface-size
which we are being passed (which is 20 px wide for our 24 px size),
but gets applied a second time using scaling squashing the image
and making the progress circle non round.

This commit fixes this by removing the padding, as gnome shell
automatically adds plenty of padding and directly requesting 20x20 as
surface size, which results in a 20x27 surface as we are given the full
height of the panel as height, but our own padding code takes care of
that.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>